### PR TITLE
Remove password after update

### DIFF
--- a/server/controllers/users.js
+++ b/server/controllers/users.js
@@ -135,6 +135,7 @@
               }
               return resolveError(err, res, 409);
             }
+            user.password = null;
             return res.status(200).send(user);
           });
         });


### PR DESCRIPTION
### What this PR does.

Removes the password field from the user details after updating the user.
This prevents the hashed password from being leaked to the end user.
### Relevant Pivotal Tracker Stories.

[Don't return the password alongside user details after update.](https://www.pivotaltracker.com/projects/1590677/stories/120321151)
