### PR TITLE
[Finish #121953023] Hide `admin` role from the UI

### DIFF
--- a/client/src/components/Documents/CreateOrUpdateDocument.jsx
+++ b/client/src/components/Documents/CreateOrUpdateDocument.jsx
@@ -109,14 +109,17 @@ const CreateOrUpdateDocument = (props) => {
             onChange={props.onRoleFieldUpdate}
             value={props.documentContent.role || 'public'}
           >
-            {props.roles.map((role) => (
-              <MenuItem
-                key={role._id}
-                label={role.title}
-                primaryText={role.title}
-                value={role.title}
-              />
-            ))}
+            {props.roles
+              .filter(role => role.title !== 'admin')
+              .map((role) => (
+                <MenuItem
+                  key={role._id}
+                  label={role.title}
+                  primaryText={role.title}
+                  value={role.title}
+                />
+              ))
+            }
           </SelectField>
         </div>
       </Dialog>

--- a/client/src/components/Documents/Document.jsx
+++ b/client/src/components/Documents/Document.jsx
@@ -38,7 +38,10 @@ const Document = (props) => {
       <CardHeader
         avatar={`${ownerGravatar}&s=40`}
         style={{ paddingBottom: '0.5em' }}
-        subtitle={owner && owner.role ? owner.role.title : ''}
+        subtitle={owner && owner.role && owner.role.title === 'admin'
+          ? owner.role.title
+          : `@${owner.username}`
+        }
         title={
           <Link
             className='username-link'

--- a/client/src/components/MainAppNavBar/MainAppNavBar.jsx
+++ b/client/src/components/MainAppNavBar/MainAppNavBar.jsx
@@ -10,7 +10,7 @@ import MenuIcon from 'material-ui/svg-icons/navigation/menu';
 import ContentFilter from 'material-ui/svg-icons/content/filter-list';
 
 const NavBar = (props) => {
-  const FILTERS = ['all'].concat(['user', 'public', 'admin', 'private'].sort());
+  const FILTERS = ['all'].concat(['user', 'public', 'private'].sort());
   return (
     <div className='main-application__navbar'>
       <AppBar

--- a/client/src/components/UserSidebar/UserProfileUpdate.jsx
+++ b/client/src/components/UserSidebar/UserProfileUpdate.jsx
@@ -28,7 +28,10 @@ const UserSideBarUpdate = (props) => {
       <Card className='sidebar-card' zDepth={3}>
         <CardHeader
           avatar={`${userGravatar}&s=40`}
-          subtitle={user && user.role ? user.role.title : ''}
+          subtitle={user && user.role && user.role.title === 'admin'
+            ? user.role.title
+            : `@${user.username}`
+          }
           title={user.name
             ? `${user.name.firstName} ${user.name.lastName}`
             : user.username

--- a/client/src/components/UserSidebar/UserSidebar.jsx
+++ b/client/src/components/UserSidebar/UserSidebar.jsx
@@ -20,7 +20,10 @@ const UserSidebar = (props) => {
       <Card className='sidebar-card'>
         <CardHeader
           avatar={`${userGravatar}&s=40`}
-          subtitle={user && user.role ? user.role.title : ''}
+          subtitle={user && user.role && user.role.title === 'admin'
+            ? user.role.title
+            : `@${user.username}`
+          }
           title={user.name
             ? `${user.name.firstName} ${user.name.lastName}`
             : user.username


### PR DESCRIPTION
### What this PR does

Hides the `admin` role from the UI.
Shows users' usernames alongside the avatar instead of their roles if they are not admins.
### Relevant Pivotal Tracker stories

[Hide admin role from the UI](https://www.pivotaltracker.com/story/show/121953023)
