### PR TITLE
[Finish #122187417] Remove the username overlay from profile picture.

### DIFF
--- a/client/src/components/UserSidebar/UserSidebar.jsx
+++ b/client/src/components/UserSidebar/UserSidebar.jsx
@@ -50,16 +50,7 @@ const UserSidebar = (props) => {
           : null
           }
         </CardHeader>
-        <CardMedia
-          overlay={
-            <CardTitle
-              subtitle={user.name
-                ? `${user.name.firstName} ${user.name.lastName}`
-                : user.username
-              }
-            />
-          }
-        >
+        <CardMedia>
           <img role='presentation' src={`${userGravatar}&s=300`} />
         </CardMedia>
         <CardTitle


### PR DESCRIPTION
### What this PR does

Removes the username overlay on the user profile image.
### Relevant Pivotal Tracker stories

[Remove the username overlay from profile picture.](https://www.pivotaltracker.com/story/show/122187417)
